### PR TITLE
Add an option to only return add-ons that have a WebExtension version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amoid",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Convert between different AMO identifier formats",
   "main": "index.js",
   "bin": "index.js",


### PR DESCRIPTION
@wagnerand can you take a quick look at this to see if I am missing any edge cases? I'd like a way to filter a list by WebExtensions only.